### PR TITLE
⚡ Bolt: Optimize JSONUtils file parsing using streaming Gson reader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Avoid large file buffer into memory
+**Learning:** For a ~900KB json file containing 18k lines, buffering into a `StringWriter` line-by-line via `BufferedReader` wastes memory and GC time. The Gson library natively handles `InputStreamReader` streams which avoids holding the entire string in memory at once.
+**Action:** Use streaming parsers/readers whenever directly possible instead of loading an entire large file as a single String object into memory.

--- a/app/src/main/java/com/projectdelta/jim/util/JSONUtils.java
+++ b/app/src/main/java/com/projectdelta/jim/util/JSONUtils.java
@@ -5,11 +5,8 @@ import android.content.res.Resources;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -29,16 +26,12 @@ public class JSONUtils {
     public static <T> Optional<T> getJsonFileAsClass(final Resources resources, final int resId, final Class<T> classType) {
 
         InputStream resourceReader = resources.openRawResource(resId);
-        Writer writer = new StringWriter();
 
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReader, StandardCharsets.UTF_8));
-            String line = reader.readLine();
-            while (line != null) {
-                writer.write(line);
-                line = reader.readLine();
-            }
-            return Optional.of(constructUsingGson(classType, writer.toString()));
+            // ⚡ Bolt: Parse directly from the stream instead of loading the entire string into memory.
+            // This reduces memory usage and avoids redundant string allocation, especially for large JSON files.
+            InputStreamReader reader = new InputStreamReader(resourceReader, StandardCharsets.UTF_8);
+            return Optional.of(constructUsingGson(classType, reader));
         } catch (Exception e) {
             // Crashlytics.logException(e);
             Timber.e(e, "Unhandled exception while using JSONResourceReader");
@@ -55,11 +48,12 @@ public class JSONUtils {
     /**
      * Build an object from the specified JSON resource using Gson.
      *
-     * @param type The type of the object to build.
+     * @param type   The type of the object to build.
+     * @param reader The InputStreamReader containing the JSON.
      * @return An object of type T, with member fields populated using Gson.
      */
-    private static <T> T constructUsingGson(final Class<T> type, final String jsonString) {
+    private static <T> T constructUsingGson(final Class<T> type, final InputStreamReader reader) {
         Gson gson = new GsonBuilder().create();
-        return gson.fromJson(jsonString, type);
+        return gson.fromJson(reader, type);
     }
 }


### PR DESCRIPTION
💡 What: Refactored `JSONUtils.getJsonFileAsClass` to pass `InputStreamReader` directly to `Gson` rather than buffering the entire file into memory as a `String`.

🎯 Why: The previous implementation iterated line-by-line using a `BufferedReader` and a `StringWriter` to concatenate a very large ~900KB JSON file (`exercises.json`), resulting in huge string allocations and excessive GC overhead.

📊 Impact: Reduces memory usage and parsing time during JSON load.

🔬 Measurement: Verifiable by testing application start / parsing overhead. Ensure no regressions occur in `MockDebugData` generation or any usage of `JSONUtils`. Tests via `./gradlew testDebugUnitTest` continue to pass.

---
*PR created automatically by Jules for task [12467195662348668196](https://jules.google.com/task/12467195662348668196) started by @sarafanshul*