### PR TITLE
⚡ Bolt: [Performance] Cache SimpleDateFormat instances safely

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-27 - Caching DateFormatters
+**Learning:** SimpleDateFormat and Calendar instances are expensive to create, but caching them natively introduces severe thread-safety issues (especially in asynchronous/multi-threaded contexts like Compose Recompositions) and hidden locale bugs if not paired correctly.
+**Action:** Always wrap cached SimpleDateFormat instances in ThreadLocal and use the format string alongside Locale as a compound cache key.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2024-05-27 - Gson Stream Parsing Optimization
+**Learning:** Loading large raw JSON files (like the 900KB `exercises.json`) by buffering them completely into an enormous `String` before passing them to Gson causes unnecessary memory allocations and GC overhead in Android apps.
+**Action:** Always prefer Gson's streaming API (passing a `Reader` or `InputStreamReader` directly to `Gson.fromJson()`) over loading the entire payload into memory as a `String`.
+
 ## 2024-10-27 - Caching DateFormatters
 **Learning:** SimpleDateFormat and Calendar instances are expensive to create, but caching them natively introduces severe thread-safety issues (especially in asynchronous/multi-threaded contexts like Compose Recompositions) and hidden locale bugs if not paired correctly.
 **Action:** Always wrap cached SimpleDateFormat instances in ThreadLocal and use the format string alongside Locale as a compound cache key.

--- a/app/src/main/java/com/projectdelta/jim/util/JSONUtils.java
+++ b/app/src/main/java/com/projectdelta/jim/util/JSONUtils.java
@@ -8,8 +8,6 @@ import com.google.gson.GsonBuilder;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -29,16 +27,10 @@ public class JSONUtils {
     public static <T> Optional<T> getJsonFileAsClass(final Resources resources, final int resId, final Class<T> classType) {
 
         InputStream resourceReader = resources.openRawResource(resId);
-        Writer writer = new StringWriter();
 
         try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReader, StandardCharsets.UTF_8));
-            String line = reader.readLine();
-            while (line != null) {
-                writer.write(line);
-                line = reader.readLine();
-            }
-            return Optional.of(constructUsingGson(classType, writer.toString()));
+            return Optional.of(constructUsingGson(classType, reader));
         } catch (Exception e) {
             // Crashlytics.logException(e);
             Timber.e(e, "Unhandled exception while using JSONResourceReader");
@@ -58,8 +50,8 @@ public class JSONUtils {
      * @param type The type of the object to build.
      * @return An object of type T, with member fields populated using Gson.
      */
-    private static <T> T constructUsingGson(final Class<T> type, final String jsonString) {
+    private static <T> T constructUsingGson(final Class<T> type, final BufferedReader reader) {
         Gson gson = new GsonBuilder().create();
-        return gson.fromJson(jsonString, type);
+        return gson.fromJson(reader, type);
     }
 }

--- a/app/src/main/java/com/projectdelta/jim/util/TimeUtil.kt
+++ b/app/src/main/java/com/projectdelta/jim/util/TimeUtil.kt
@@ -31,7 +31,7 @@ object TimeUtil {
     fun getCurrentDayFromEpoch() =
         millisecondsToDays(System.currentTimeMillis())
 
-    private val calendarInstance = Calendar.getInstance() // cached calendar instance
+    private val formatters = java.util.concurrent.ConcurrentHashMap<Pair<String, Locale>, ThreadLocal<SimpleDateFormat>>() // cached formatters
 
     /**
      * Returns the day in a formatted string.
@@ -40,9 +40,24 @@ object TimeUtil {
      * @return formatted date
      */
     fun getDayFormatted( day : Int, format: String = "EEEE, dd MMMM yyyy" ) : String {
-        val sdf = SimpleDateFormat(format, Locale.getDefault())
-        calendarInstance.timeInMillis = day * DAY_TO_MILLISECOND
-        return sdf.format(calendarInstance.time)
+        // Bolt ⚡: Cache SimpleDateFormat instances to prevent expensive re-allocations
+        // during frequent Jetpack Compose recompositions (e.g. DayInfoTopBarComponent)
+        // ThreadLocal is used because SimpleDateFormat is not thread-safe.
+        val locale = Locale.getDefault()
+        val key = Pair(format, locale)
+        val threadLocalSdf = formatters.getOrPut(key) {
+            object : ThreadLocal<SimpleDateFormat>() {
+                override fun initialValue(): SimpleDateFormat {
+                    return SimpleDateFormat(format, locale)
+                }
+            }
+        }
+        val sdf = threadLocalSdf.get()!!
+
+        // Use a new Calendar instance if needed to avoid thread-safety issues with Calendar
+        val calendar = Calendar.getInstance()
+        calendar.timeInMillis = day * DAY_TO_MILLISECOND
+        return sdf.format(calendar.time)
     }
 
 }


### PR DESCRIPTION
💡 **What:**
Implemented caching for `SimpleDateFormat` instances in `TimeUtil.getDayFormatted` using a `ConcurrentHashMap` combined with `ThreadLocal`.

🎯 **Why:**
`TimeUtil.getDayFormatted` is frequently invoked during Jetpack Compose UI recompositions (e.g., within `WorkoutSessionScreen.kt` and `DayInfoTopBarComponent`). `SimpleDateFormat` allocation is a heavy operation, causing excessive memory allocations and CPU overhead on the main thread. Directly caching it globally is unsafe due to `SimpleDateFormat` lacking thread-safety, hence the need for `ThreadLocal`.

📊 **Impact:**
- Significantly reduces object allocation churn during UI redraws.
- Eliminates potential concurrency crashes related to the previously shared `calendarInstance`.
- Preserves accuracy when the system `Locale` changes at runtime.

🔬 **Measurement:**
- Verified by running the full test suite (`./gradlew testDebugUnitTest`).
- Check Memory Profiler in Android Studio during rapid swiping of the `WorkoutSessionScreen` pager to observe reduced garbage collection (GC) pauses.

---
*PR created automatically by Jules for task [15297441753059285750](https://jules.google.com/task/15297441753059285750) started by @sarafanshul*