### PR TITLE
⚡ Bolt: [performance improvement] Added database indices to Room foreign keys

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-27 - Gson Stream Parsing Optimization
 **Learning:** Loading large raw JSON files (like the 900KB `exercises.json`) by buffering them completely into an enormous `String` before passing them to Gson causes unnecessary memory allocations and GC overhead in Android apps.
 **Action:** Always prefer Gson's streaming API (passing a `Reader` or `InputStreamReader` directly to `Gson.fromJson()`) over loading the entire payload into memory as a `String`.
+## 2026-05-30 - Room Database Schema Migration
+**Learning:** When adding indices to Room database entities for performance optimization, failing to bump the database version and provide a corresponding `Migration` strategy will cause a hard crash (`IllegalStateException`) for existing users due to schema hash mismatch. Furthermore, one should never manually edit the historical `1.json` schema files.
+**Action:** Always increment the database version (e.g. in `Constants.kt`), define a proper `Migration` object (e.g., executing `CREATE INDEX IF NOT EXISTS` scripts), and register it via `.addMigrations()` in the Room database builder whenever adding indices or modifying entities.

--- a/app/schemas/com.projectdelta.jim.data.local.JimDatabase/2.json
+++ b/app/schemas/com.projectdelta.jim.data.local.JimDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "7dcbe4a8f697b4e365526bbd16b1142b",
+    "identityHash": "0ef4ce200363012e249c82a19403be8e",
     "entities": [
       {
         "tableName": "exercise_table",
@@ -75,29 +75,27 @@
             "id"
           ]
         },
-        "indices": [],
+        "indices": [
+          {
+            "name": "index_exercise_table_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exercise_table_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
         "foreignKeys": []
       },
       {
         "tableName": "workout_session_table",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timeMs` INTEGER NOT NULL, `workouts` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
             "columnName": "id",
             "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "timeMs",
-            "columnName": "timeMs",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "workouts",
-            "columnName": "workouts",
-            "affinity": "TEXT",
             "notNull": true
           }
         ],
@@ -109,12 +107,138 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "workout_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `exerciseId` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_table_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_table_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_workout_table_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_table_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "workout_set_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `note` TEXT NOT NULL, `weight` REAL NOT NULL, `reps` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `workoutId` INTEGER NOT NULL, `exerciseId` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_set_table_workoutId",
+            "unique": false,
+            "columnNames": [
+              "workoutId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_set_table_workoutId` ON `${TABLE_NAME}` (`workoutId`)"
+          },
+          {
+            "name": "index_workout_set_table_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_set_table_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7dcbe4a8f697b4e365526bbd16b1142b')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0ef4ce200363012e249c82a19403be8e')"
     ]
   }
 }

--- a/app/src/main/java/com/projectdelta/jim/data/local/JimDatabase.kt
+++ b/app/src/main/java/com/projectdelta/jim/data/local/JimDatabase.kt
@@ -61,12 +61,22 @@ abstract class JimDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_1_2 = object : androidx.room.migration.Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_table_sessionId` ON `workout_table` (`sessionId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_table_exerciseId` ON `workout_table` (`exerciseId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_set_table_workoutId` ON `workout_set_table` (`workoutId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_set_table_exerciseId` ON `workout_set_table` (`exerciseId`)")
+            }
+        }
+
         private fun buildDatabase(application: Application): JimDatabase {
             return Room.databaseBuilder(
                 application,
                 JimDatabase::class.java,
                 NAME
-            ).addCallback(object : Callback() {
+            ).addMigrations(MIGRATION_1_2)
+            .addCallback(object : Callback() {
                 override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
                     super.onDestructiveMigration(db)
                 }

--- a/app/src/main/java/com/projectdelta/jim/data/model/entity/Workout.kt
+++ b/app/src/main/java/com/projectdelta/jim/data/model/entity/Workout.kt
@@ -13,7 +13,13 @@ import kotlinx.parcelize.Parcelize
  * Denotes a Workout, mapped with respective objects.
  */
 @Keep
-@Entity(tableName = WORKOUT_TABLE)
+@Entity(
+    tableName = WORKOUT_TABLE,
+    indices = [
+        androidx.room.Index("sessionId"),
+        androidx.room.Index("exerciseId")
+    ]
+)
 @Parcelize
 data class Workout(
 

--- a/app/src/main/java/com/projectdelta/jim/data/model/entity/WorkoutSet.kt
+++ b/app/src/main/java/com/projectdelta/jim/data/model/entity/WorkoutSet.kt
@@ -15,7 +15,13 @@ import kotlinx.parcelize.Parcelize
  */
 @Keep
 @Parcelize
-@Entity(tableName = WORKOUT_SET_TABLE)
+@Entity(
+    tableName = WORKOUT_SET_TABLE,
+    indices = [
+        androidx.room.Index("workoutId"),
+        androidx.room.Index("exerciseId")
+    ]
+)
 data class WorkoutSet(
 
     /**

--- a/app/src/main/java/com/projectdelta/jim/util/Constants.kt
+++ b/app/src/main/java/com/projectdelta/jim/util/Constants.kt
@@ -23,7 +23,7 @@ object Constants {
      */
     object Database {
         const val NAME = "jim_database"
-        const val VERSION = 1
+        const val VERSION = 2
     }
 
     /**


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Added database indices to Room foreign keys

💡 What:
Added `@Index` annotations for frequently queried foreign keys (`sessionId`, `workoutId`, `exerciseId`) in the Room database entities (`Workout` and `WorkoutSet`). Also bumped the database version and provided a safe `Migration` object.

🎯 Why:
Without these indices, any relations in Room that map entities by matching IDs will perform a full table scan, degrading performance and increasing UI load times as the dataset grows.

📊 Impact:
Significantly reduces query execution time for resolving nested entities (e.g., retrieving workouts and sets associated with a session), avoiding full table scans.

🔬 Measurement:
Observe UI responsiveness when rendering heavily-populated workout logs, or use Android Studio's Database Inspector to run `EXPLAIN QUERY PLAN` on join queries involving these keys to confirm index usage.

---
*PR created automatically by Jules for task [14397644554145613458](https://jules.google.com/task/14397644554145613458) started by @sarafanshul*