### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-27 - Gson Stream Parsing Optimization
 **Learning:** Loading large raw JSON files (like the 900KB `exercises.json`) by buffering them completely into an enormous `String` before passing them to Gson causes unnecessary memory allocations and GC overhead in Android apps.
 **Action:** Always prefer Gson's streaming API (passing a `Reader` or `InputStreamReader` directly to `Gson.fromJson()`) over loading the entire payload into memory as a `String`.
+## 2024-06-25 - Room Relations and Full Table Scans
+**Learning:** In Room database, using `@Relation` annotations without providing explicit indices for the mapped parent/child columns leads to significant performance sinks because Room performs full-table scans to resolve the relationships.
+**Action:** Always verify that foreign keys or columns heavily used in `@Relation` queries are indexed using `@Entity(indices = [...])`, increment the Database version, and implement proper Migration scripts to deploy indices safely to existing users.

--- a/app/src/main/java/com/projectdelta/jim/data/local/JimDatabase.kt
+++ b/app/src/main/java/com/projectdelta/jim/data/local/JimDatabase.kt
@@ -23,6 +23,7 @@ import com.projectdelta.jim.util.Converters
 import com.projectdelta.jim.util.JSONUtils
 import com.projectdelta.jim.util.MockDebugData
 import java.util.concurrent.Executors
+import androidx.room.migration.Migration
 
 @Database(
     entities = [
@@ -49,6 +50,15 @@ abstract class JimDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: JimDatabase? = null
 
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_table_sessionId` ON `workout_table` (`sessionId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_table_exerciseId` ON `workout_table` (`exerciseId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_set_table_workoutId` ON `workout_set_table` (`workoutId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_workout_set_table_exerciseId` ON `workout_set_table` (`exerciseId`)")
+            }
+        }
+
         fun getInstance(application: Application): JimDatabase {
             val tempInstance = INSTANCE
             if (tempInstance != null)
@@ -66,7 +76,8 @@ abstract class JimDatabase : RoomDatabase() {
                 application,
                 JimDatabase::class.java,
                 NAME
-            ).addCallback(object : Callback() {
+            ).addMigrations(MIGRATION_1_2)
+            .addCallback(object : Callback() {
                 override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
                     super.onDestructiveMigration(db)
                 }

--- a/app/src/main/java/com/projectdelta/jim/data/model/entity/Workout.kt
+++ b/app/src/main/java/com/projectdelta/jim/data/model/entity/Workout.kt
@@ -13,7 +13,13 @@ import kotlinx.parcelize.Parcelize
  * Denotes a Workout, mapped with respective objects.
  */
 @Keep
-@Entity(tableName = WORKOUT_TABLE)
+@Entity(
+    tableName = WORKOUT_TABLE,
+    indices = [
+        androidx.room.Index(value = ["sessionId"]),
+        androidx.room.Index(value = ["exerciseId"])
+    ]
+)
 @Parcelize
 data class Workout(
 

--- a/app/src/main/java/com/projectdelta/jim/data/model/entity/WorkoutSet.kt
+++ b/app/src/main/java/com/projectdelta/jim/data/model/entity/WorkoutSet.kt
@@ -15,7 +15,13 @@ import kotlinx.parcelize.Parcelize
  */
 @Keep
 @Parcelize
-@Entity(tableName = WORKOUT_SET_TABLE)
+@Entity(
+    tableName = WORKOUT_SET_TABLE,
+    indices = [
+        androidx.room.Index(value = ["workoutId"]),
+        androidx.room.Index(value = ["exerciseId"])
+    ]
+)
 data class WorkoutSet(
 
     /**

--- a/app/src/main/java/com/projectdelta/jim/util/Constants.kt
+++ b/app/src/main/java/com/projectdelta/jim/util/Constants.kt
@@ -23,7 +23,7 @@ object Constants {
      */
     object Database {
         const val NAME = "jim_database"
-        const val VERSION = 1
+        const val VERSION = 2
     }
 
     /**


### PR DESCRIPTION
💡 What: Added missing explicit `indices` for the relation columns `sessionId` and `exerciseId` in `Workout.kt`, and `workoutId` and `exerciseId` in `WorkoutSet.kt`. Incremented database version to 2 and added an explicit SQLite migration script.
🎯 Why: Room `@Relation` annotations without indexed foreign key columns cause the database to perform full-table scans to resolve relationships. This severely limits read performance when looking up nested lists of sets and workouts.
📊 Impact: Lookups for workout sessions or specific workouts by their IDs change from O(N) full table scans to O(1)/O(logN) index lookups, vastly reducing query execution time and CPU overhead as the database grows.
🔬 Measurement: Performance can be measured by inspecting query execution times using SQLite EXPLAIN QUERY PLAN or database profiling for queries matching `sessionId` or `workoutId`.

---
*PR created automatically by Jules for task [18426193187284454316](https://jules.google.com/task/18426193187284454316) started by @sarafanshul*